### PR TITLE
New Dockerfile using alpine-golang-make-onbuild base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,4 @@
-FROM alpine:3.2
-MAINTAINER The Prometheus Authors <prometheus-developers@googlegroups.com>
-
-ENV GOPATH /go
-COPY . /go/src/github.com/prometheus/nginx_exporter
-
-RUN apk add --update -t build-deps go git mercurial make \
-    && apk add -u musl && rm -rf /var/cache/apk/* \
-    && cd /go/src/github.com/prometheus/nginx_exporter \
-    && make && cp nginx_exporter /bin/nginx_exporter \
-    && rm -rf /go && apk del --purge build-deps
+FROM        sdurrheimer/alpine-golang-make-onbuild
+MAINTAINER  The Prometheus Authors <prometheus-developers@googlegroups.com>
 
 EXPOSE     9113
-ENTRYPOINT [ "/bin/nginx_exporter" ]

--- a/README.md
+++ b/README.md
@@ -14,5 +14,14 @@ Help on flags:
 ./nginx_exporter --help
 ```
 
-# Getting Started
+## Getting Started
   * All of the core developers are accessible via the [Prometheus Developers Mailinglist](https://groups.google.com/forum/?fromgroups#!forum/prometheus-developers).
+
+## Using Docker
+
+```
+docker pull fish/nginx-exporter
+
+docker run -d -p 9113:9113 fish/nginx-exporter \
+    -nginx.scrape_uri=http://172.17.42.1/nginx_status
+```


### PR DESCRIPTION
Following the docker related PR series.

New Dockerfile using the [alpine-golang-make-onbuild](https://github.com/sdurrheimer/alpine-golang-make-onbuild) base image whose goal is to unified the way to dockerize prometheus tools and exporters based on Golang.

The binary is build using make. (Golang is installed via make too, respecting the GO_VERSION).

A testable image is available under my name on Docker hub : [Link](https://registry.hub.docker.com/u/sdurrheimer/nginx-exporter/)

I have also added some Docker usage instructions in the readme.

As always, the [alpine-golang-make-onbuild](https://github.com/sdurrheimer/alpine-golang-make-onbuild)  image can be also move under Prometheus organization.

@discordianfish 