### PR TITLE
Serve index page instead of 404

### DIFF
--- a/nginx_exporter.go
+++ b/nginx_exporter.go
@@ -176,5 +176,15 @@ func main() {
 
 	log.Printf("Starting Server: %s", *listeningAddress)
 	http.Handle(*metricsEndpoint, prometheus.Handler())
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`<html>
+			<head><title>Nginx Exporter</title></head>
+			<body>
+			<h1>Nginx Exporter</h1>
+			<p><a href="` + *metricsEndpoint + `">Metrics</a></p>
+			</body>
+			</html>`))
+	})
+
 	log.Fatal(http.ListenAndServe(*listeningAddress, nil))
 }


### PR DESCRIPTION
I use the exporter with consul. In consul the health check fails because the exporter returns a 404 for "GET /".