### PR TITLE
use alpine for building the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,14 @@
-FROM        sdurrheimer/alpine-golang-make-onbuild
-MAINTAINER  The Prometheus Authors <prometheus-developers@googlegroups.com>
+FROM alpine:latest
 
-EXPOSE     9113
+ENV GOPATH /go
+ENV APPPATH $GOPATH/src/github.com/discordianfish/nginx_exporter
+
+COPY . $APPPATH
+
+RUN apk add --update -t build-deps go git mercurial \
+    && cd $APPPATH && go get -d && go build -o /nginx_exporter \
+    && apk del --purge build-deps git mercurial && rm -rf $GOPATH
+
+EXPOSE 9113
+
+ENTRYPOINT ["/nginx_exporter"]


### PR DESCRIPTION
With this approach i could reduce the image size from 21.04 MB to 14.87 MB. Also a newer Golang Version is used.
