### PR TITLE
an earlier merge accidentally removed this line, adding it back in

### DIFF
--- a/nginx_exporter.go
+++ b/nginx_exporter.go
@@ -162,6 +162,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 		e.scrapeFailures.Inc()
 		e.scrapeFailures.Collect(ch)
 	}
+	e.currentConnections.Collect(ch)
 	return
 }
 


### PR DESCRIPTION
https://github.com/discordianfish/nginx_exporter/commit/af0452869203b02dc952ef3fd8d12aa42de412b7 accidentally removed the export of the active and waiting connections

After putting this one line back in: 
```
# HELP nginx_connections_current Number of connections currently processed by nginx
# TYPE nginx_connections_current gauge
nginx_connections_current{state="active"} 1
nginx_connections_current{state="reading"} 0
nginx_connections_current{state="waiting"} 0
nginx_connections_current{state="writing"} 1
```