### PR TITLE
Ensure that the exporter is built statically.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:1.9
 WORKDIR /go/src/github.com/discordianfish/nginx_exporter
 COPY . .
-RUN  go get -d && go build
+RUN  go get -d && CGO_ENABLED=0 go build --ldflags '-extldflags "-static"'
 
 
 FROM quay.io/prometheus/busybox:glibc


### PR DESCRIPTION
As the image the exporter is copied into uses a different C library, we
should ensure that we build a statically linked executable. This should
fix discordianfish/nginx_exporter#23.