### PR TITLE
Build without CGO requirement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM golang:1.9
 WORKDIR /go/src/github.com/discordianfish/nginx_exporter
 COPY . .
-RUN  go get -d && go build
+RUN set -xe; \
+  go get -d; \
+  CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo;
 
 
-FROM quay.io/prometheus/busybox:glibc
+FROM quay.io/prometheus/busybox
 EXPOSE 9113
 COPY --from=0 /go/src/github.com/discordianfish/nginx_exporter/nginx_exporter /bin/
 USER nobody


### PR DESCRIPTION
Current master was giving me an error:

```
$ docker run -it --rm f0e08773d3c7
/bin/nginx_exporter: relocation error: /lib/libpthread.so.0: symbol h_errno, version GLIBC_PRIVATE 
```

But this branch works for me:

```
$ docker run -it --rm 9e112330ff1e                                                                                                                                                                          
INFO[0000] Starting Server: :9113                        file=nginx_exporter.go line=185
^C%
```

The new version is also smaller:

```
fish/nginx-exporter                                     latest              9e112330ff1e        2 hours ago         10.3MB
fish/nginx-exporter                                     <none>              f0e08773d3c7        3 days ago          13.8MB
```