### PR TITLE
goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,22 @@
+# .goreleaser.yml
+# Build customization
+builds:
+  - main: nginx_exporter.go
+    binary: nginx_exporter
+    goos:
+      - windows
+      - darwin
+      - linux
+    goarch:
+      - amd64
+      - arm
+      - arm64
+      - 386
+      
+# Archive customization
+archive:
+  format: tar.gz
+  files:
+    - LICENSE
+sign:
+  artifacts: all


### PR DESCRIPTION
Add config for releasing binaries for various platforms, so that users don't have to build them themselves.

Usage is:
- commit, push and tag new version (e.g. `v1.1.2`)
- `run go get github.com/goreleaser/goreleaser` (only the first time)
- `export GITHUB_TOKEN=YOUR_TOKEN` (generated with repo scope)
- `goreleaser --rm-dist [--release-notes FILE] [--skip-publish if you want to test it]` - this will build all binaries, archive them to tar.gz and create new release on github

for more info see https://goreleaser.com/