### PR TITLE
Add simple health check

### DIFF
--- a/nginx_exporter.go
+++ b/nginx_exporter.go
@@ -193,6 +193,9 @@ func main() {
 			</body>
 			</html>`))
 	})
-
+	http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		w.Write([]byte("ok"))
+	})
 	log.Fatal(http.ListenAndServe(*listeningAddress, nil))
 }

--- a/nginx_exporter.go
+++ b/nginx_exporter.go
@@ -193,7 +193,7 @@ func main() {
 			</body>
 			</html>`))
 	})
-	http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc("/-/healthy", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		w.Write([]byte("ok"))
 	})


### PR DESCRIPTION
Useful to check health status of a running container using a `livenessProbe` in a Kubernetes Pod.