### PR TITLE
Fix nginx_exporter_test

### DIFF
--- a/nginx_exporter_test.go
+++ b/nginx_exporter_test.go
@@ -14,7 +14,7 @@ server accepts handled requests
  145249 145249 151557 
 Reading: 0 Writing: 24 Waiting: 66 
 `
-	metricCount = 7
+	metricCount = 8
 )
 
 func TestNginxStatus(t *testing.T) {


### PR DESCRIPTION
Change metricCount to 8, metrics being collected are:

- nginxUp * 1
- currentConnections * 4
- processedConnections * 3

Not visible in test case:
- scrapeFailures * 1